### PR TITLE
Add Turtle.Format.makePrinter function

### DIFF
--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -113,7 +113,7 @@ format fmt = fmt >>- id
 Can be useful for making custom "printf" and/or "eprintf" functions that would
 use some logger function instead of stdout/stderr within some logger monad.
 
->>> makePrinter (liftIO . Data.Text.putStr)
+> printf = makePrinter (liftIO . Data.Text.putStr)
 -}
 makePrinter :: (Text -> m ()) -> Format (m ()) r -> r
 makePrinter = flip (>>-)

--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -110,7 +110,7 @@ format fmt = fmt >>- id
 
 {-| Create your own formatted printer function
 
-Can be useful for making custom "printf" and/or "eprintf" functions that would
+Can be useful for making custom 'printf' and/or 'eprintf' functions that would
 use some logger function instead of stdout/stderr within some logger monad.
 
 > printf = makePrinter (liftIO . Data.Text.putStr)


### PR DESCRIPTION
I was trying to implement some abstraction on top of Turtle to redirect the default output (stdout and/or stderr) to a logger function withing some monad where the logger is available. While I was able to implement most of the Turtle function in one way or another it turned out it’s not that trivial to implement custom `printf` and `eprintf` since `(>>-)` of `Turtle.Format.Format` is not exposed.

This change adds `makePrinter` function that just adds extra argument for `printf` that is a printer function ending with `m ()` as `Format` result. The implementation is trivial (`flip (>>-)`), `printf` and `eprintf` are reimplemented using this function.