### PR TITLE
Expose Turtle.Format.Format constructor

### DIFF
--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -42,7 +42,7 @@
 
 module Turtle.Format (
     -- * Format
-      Format
+      Format (..)
     , (%)
     , format
     , printf


### PR DESCRIPTION
I was trying to implement some abstraction on top of Turtle to redirect the default output (stdout and/or stderr) to a logger function within some monad where the logger is available. While I was able to implement most of the Turtle functions in one way or another it turned out it’s not that trivial to implement custom `printf` and `eprintf` since `(>>-)` of `Turtle.Format.Format` is not exposed.