### PR TITLE
Add latest Win32 support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 cabal.sandbox.config
 .stack-work
 tags
+dist-newstyle
+stack.yaml.lock

--- a/src/Turtle/Prelude.hs
+++ b/src/Turtle/Prelude.hs
@@ -1237,7 +1237,7 @@ touch file = do
                 Nothing
             (creationTime, _, _) <- Win32.getFileTime handle
             systemTime <- Win32.getSystemTimeAsFileTime
-            Win32.setFileTime handle creationTime systemTime systemTime
+            Win32.setFileTime handle (Just creationTime) (Just systemTime) (Just systemTime)
 #else
         then touchFile (Filesystem.encodeString file)
 #endif

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,1 @@
-resolver: lts-7.24
-extra-deps:
-- optparse-applicative-0.13.0.0
+resolver: lts-19.5

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -42,7 +42,7 @@ Category: System
 
 Tested-With:
   GHC == 9.2.1
-  GHC == 9.0.1
+  GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
   GHC == 8.6.5
@@ -85,7 +85,7 @@ Library
         optional-args        >= 1.0     && < 2.0 ,
         unix-compat          >= 0.4     && < 0.6
     if os(windows)
-        Build-Depends: Win32 >= 2.2.0.1 && < 2.9
+        Build-Depends: Win32 >= 2.12
     else
         Build-Depends: unix  >= 2.5.1.0 && < 2.8
 


### PR DESCRIPTION
(and also fix compilation errors when installing turtle with stack.)

- Changed Win32 from <2.9 to >=2.12.
- *Just* changed the call to setFileTime.
- Set LTS version to 19.5 and changed Tested-With GHC 9.0.1 to newer 9.0.2.